### PR TITLE
refactor: store errors found in Checker

### DIFF
--- a/src/rules/key_and_eng_matches.rs
+++ b/src/rules/key_and_eng_matches.rs
@@ -1,6 +1,7 @@
 use parser::{LocaleKeyParser, LocaleToken};
 
 use super::Rule;
+use std::collections::HashMap;
 
 /// A rules that enforces a locale's key matches its English translation.
 ///
@@ -13,12 +14,17 @@ impl Rule for KeyEngMatches {
         &self,
         localized_texts: &crate::locale_file_parser::LocalizedTexts,
         _locale_keys: &[crate::locale_key_collector::LocaleKey],
+        erros: &mut HashMap<String, Vec<(String, Option<String>)>>,
     ) {
         for (key, translations) in localized_texts.texts.iter() {
             let en = &translations.en;
 
             if en.is_none() {
-                Self::report_error(key.clone(), Some("Missing English translation".into()));
+                Self::report_error(
+                    key.clone(),
+                    Some("Missing English translation".into()),
+                    erros,
+                );
                 return;
             }
 
@@ -29,7 +35,7 @@ impl Rule for KeyEngMatches {
             let en = en.as_ref().unwrap();
 
             if en != &expected {
-                Self::report_error(key.clone(), None)
+                Self::report_error(key.clone(), None, erros)
             }
         }
     }

--- a/src/rules/missing_translations.rs
+++ b/src/rules/missing_translations.rs
@@ -1,5 +1,6 @@
 use super::Rule;
 use bitflags::bitflags;
+use std::collections::HashMap;
 
 bitflags! {
     /// A bitflag represent the missing languages, every language would take 1 bit.
@@ -35,6 +36,7 @@ impl Rule for MissingTranslations {
         &self,
         localized_texts: &crate::LocalizedTexts,
         _locale_keys: &[crate::locale_key_collector::LocaleKey],
+        erros: &mut HashMap<String, Vec<(String, Option<String>)>>,
     ) {
         for (key, translations) in localized_texts.texts.iter() {
             let mut missing_langs = MissingLanguages::empty();
@@ -44,7 +46,7 @@ impl Rule for MissingTranslations {
             }
 
             if !missing_langs.is_empty() {
-                Self::report_error(key.clone(), Some(missing_langs.error_msg()));
+                Self::report_error(key.clone(), Some(missing_langs.error_msg()), erros);
             }
         }
     }

--- a/src/rules/use_of_keys_do_not_exist.rs
+++ b/src/rules/use_of_keys_do_not_exist.rs
@@ -1,6 +1,7 @@
 //! A rule that checks if Topgrade uses any locale keys that do not exist.
 
 use super::Rule;
+use std::collections::HashMap;
 
 /// Checks if Topgrade uses any locale keys that do not exist.
 pub(crate) struct UseOfKeysDoNotExist;
@@ -10,6 +11,7 @@ impl Rule for UseOfKeysDoNotExist {
         &self,
         localized_texts: &crate::locale_file_parser::LocalizedTexts,
         locale_keys: &[crate::locale_key_collector::LocaleKey],
+        erros: &mut HashMap<String, Vec<(String, Option<String>)>>,
     ) {
         for locale_key in locale_keys {
             if !localized_texts.texts.contains_key(&locale_key.key) {
@@ -22,6 +24,7 @@ impl Rule for UseOfKeysDoNotExist {
                         locale_key.key
                     ),
                     None,
+                    erros,
                 );
             }
         }


### PR DESCRIPTION
### What does this PR do

After this PR, we no longer store the errors in a global variable, instead, we store them directly in the `Chcker` itself. The main rationale behind this change is that, with this change, `Rule::check()` takes an `errors` argument so that we can store the errors anywhere when invoking `Rule::check()`, which makes unit tests of `Rule` implementations possible.